### PR TITLE
fix the wrong way to visualize offsets

### DIFF
--- a/offset_visualization.py
+++ b/offset_visualization.py
@@ -82,8 +82,8 @@ def plot_offsets(img, save_output, roi_x, roi_y):
         sampling_x = sampling_x[roi_y, roi_x]
         
         for y, x in zip(sampling_y, sampling_x):
-            y = round(y)
-            x = round(x)
+            y = round(y + resize_factor_h/2)
+            x = round(x + resize_factor_w/2)
             cv2.circle(img, center=(x, y), color=(0, 0, 255), radius=1, thickness=-1)
                 
 


### PR DESCRIPTION
Hello, thanks for your repo.
I fix the calculation of sampling points.
The visualization result with the initial weight can simply verify it.
By original calculation, the red point and the green point are not aligned.
![save_image](https://user-images.githubusercontent.com/67384645/215791360-e7d6cafa-32a3-468d-b5af-892e8161df46.png)
